### PR TITLE
Add timestamps to AddressChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,6 @@ Bounded Context for the Wikimedia Deutschland fundraising address change (sub-)d
 * When exporting address-related records (donation, membership, subscription), each record has a random UUID that can be used to reference address changes to that record in the future.
 * Users can get links to the address change page, each link being secured with the UUID that identifies the address change.
 * Whenever an address changes, its UUID is regenerated.
+* Whenever an address changes, it is marked as modified (by tracking creation vs modification date). Only the last modification date is recorded.
 * Address changes are exported as individual records, with current and previous UUID.
+

--- a/config/DoctrineClassMapping/WMDE.Fundraising.AddressChange.Domain.Model.AddressChange.dcm.xml
+++ b/config/DoctrineClassMapping/WMDE.Fundraising.AddressChange.Domain.Model.AddressChange.dcm.xml
@@ -22,16 +22,10 @@
         <option name="fixed"/>
       </options>
     </field>
-    <field name="addressType" type="string" column="address_type" length="10" nullable="false">
-      <options>
-        <option name="fixed"/>
-      </options>
-    </field>
-    <field name="exportDate" type="datetime" column="export_date" nullable="true">
-      <options>
-        <option name="fixed"/>
-      </options>
-    </field>
+    <field name="addressType" type="string" column="address_type" length="10" nullable="false" />
+    <field name="exportDate" type="datetime" column="export_date" nullable="true" />
+    <field name="createdAt" type="datetime" column="created_at" nullable="false" />
+    <field name="modifiedAt" type="datetime" column="modified_at" nullable="false" />
     <many-to-one field="address" target-entity="Address" fetch="LAZY">
       <join-columns>
         <join-column name="address_id" referenced-column-name="id"/>

--- a/src/Domain/Model/AddressChange.php
+++ b/src/Domain/Model/AddressChange.php
@@ -24,7 +24,12 @@ class AddressChange {
 
 	private $exportDate;
 
-	private function __construct( string $addressType, ?string $identifier = null, ?Address $address = null ) {
+	private $createdAt;
+
+	private $modifiedAt;
+
+	private function __construct( string $addressType, ?string $identifier = null, ?Address $address = null,
+								  ?\DateTime $createdAt = null ) {
 		$this->addressType = $addressType;
 		$this->identifier = $identifier;
 		$this->address = $address;
@@ -33,14 +38,18 @@ class AddressChange {
 		} elseif ( !Uuid::isValid( $identifier ) ) {
 			throw new \InvalidArgumentException( 'Identifier must be a valid UUID' );
 		}
+		$this->createdAt = $createdAt ?? new \DateTime();
+		$this->modifiedAt = clone( $this->createdAt );
 	}
 
-	public static function createNewPersonAddressChange( ?string $identifier = null, ?Address $address = null ): self {
-		return new AddressChange( self::ADDRESS_TYPE_PERSON, $identifier, $address );
+	public static function createNewPersonAddressChange( ?string $identifier = null, ?Address $address = null,
+														 ?\DateTime $createdAt = null ): self {
+		return new AddressChange( self::ADDRESS_TYPE_PERSON, $identifier, $address, $createdAt );
 	}
 
-	public static function createNewCompanyAddressChange( ?string $identifier = null, ?Address $address = null ): self {
-		return new AddressChange( self::ADDRESS_TYPE_COMPANY, $identifier, $address );
+	public static function createNewCompanyAddressChange( ?string $identifier = null, ?Address $address = null,
+														  ?\DateTime $createdAt = null ): self {
+		return new AddressChange( self::ADDRESS_TYPE_COMPANY, $identifier, $address, $createdAt );
 	}
 
 	private function generateUuid(): void {
@@ -53,6 +62,7 @@ class AddressChange {
 		}
 		$this->address = $address;
 		$this->previousIdentifier = $this->getCurrentIdentifier();
+		$this->modifiedAt = new \DateTime();
 		$this->generateUuid();
 		$this->resetExportState();
 	}
@@ -93,5 +103,9 @@ class AddressChange {
 
 	public function isExported(): bool {
 		return $this->exportDate !== null;
+	}
+
+	public function isModified(): bool {
+		return $this->createdAt < $this->modifiedAt;
 	}
 }

--- a/tests/Unit/Domain/Model/AddressChangeTest.php
+++ b/tests/Unit/Domain/Model/AddressChangeTest.php
@@ -24,13 +24,18 @@ class AddressChangeTest extends TestCase {
 		$this->entityManager = TestEnvironment::newInstance()->getFactory()->getEntityManager();
 	}
 
-	public function testWhenNewAddressChangeIsPersisted_uuidIsGenerated() {
+	public function testWhenNewAddressChangeIsCreated_uuidIsGenerated() {
 		$addressChange = AddressChange::createNewPersonAddressChange();
 		$this->assertNotEmpty( $addressChange->getCurrentIdentifier() );
 	}
 
-	public function testWhenAddressIdentifierIsUpdated_dataIsProperlyAssigned() {
+	public function testWhenNewAddressChangeIsCreated_itIsNotModified() {
 		$addressChange = AddressChange::createNewPersonAddressChange();
+		$this->assertFalse( $addressChange->isModified() );
+	}
+
+	public function testWhenAddressIsUpdated_dataIsProperlyAssigned() {
+		$addressChange = AddressChange::createNewPersonAddressChange( null, null, new \DateTime( '1970-01-01' ) );
 		$initialIdentifier = $addressChange->getCurrentIdentifier();
 		$address = ValidAddress::newValidPersonalAddress();
 		$addressChange->performAddressChange( $address );
@@ -38,6 +43,7 @@ class AddressChangeTest extends TestCase {
 		$this->assertSame( $initialIdentifier, $addressChange->getPreviousIdentifier() );
 		$this->assertNotSame( $initialIdentifier, $addressChange->getCurrentIdentifier() );
 		$this->assertSame( $address, $addressChange->getAddress() );
+		$this->assertTrue( $addressChange->isModified() );
 	}
 
 	public function testAddressChangeCannotBePerformedTwice() {
@@ -67,6 +73,12 @@ class AddressChangeTest extends TestCase {
 		$this->expectException( \LogicException::class );
 
 		$addressChange->markAsExported();
+	}
+
+	public function testMarkingAsExportedDoesNotChangeModificationDate() {
+		$addressChange = AddressChange::createNewPersonAddressChange();
+		$addressChange->markAsExported();
+		$this->assertFalse( $addressChange->isModified() );
 	}
 
 	public function testWhenAddressChangeIsPerformed_exportStateIsReset() {


### PR DESCRIPTION
Track creation and modification date
Change modification date when address is changed (but not when
exported).

Improve test names for a more descriptive behavior.
Add tests for checking export date when writing to DB.

https://phabricator.wikimedia.org/T214916