### PR TITLE
Rename domain properties

### DIFF
--- a/src/UseCases/ChangeAddress/ChangeAddressRequest.php
+++ b/src/UseCases/ChangeAddress/ChangeAddressRequest.php
@@ -154,8 +154,8 @@ class ChangeAddressRequest {
 		return $this;
 	}
 
-	public function isOptedIntoDonationReceipt(): bool {
-		return $this->donationReceipt;
+	public function isOptedOutOfDonationReceipt(): bool {
+		return ! $this->donationReceipt;
 	}
 
 	public function setDonationReceipt( bool $donationReceipt ): self {
@@ -170,8 +170,8 @@ class ChangeAddressRequest {
 		return $this;
 	}
 
-	public function isOnlyOptInDonationReceiptRequest(): bool {
-		return $this->isOptOutOnly;
+	public function hasAddressChangeData(): bool {
+		return ! $this->isOptOutOnly;
 	}
 
 }

--- a/src/UseCases/ChangeAddress/ChangeAddressUseCase.php
+++ b/src/UseCases/ChangeAddress/ChangeAddressUseCase.php
@@ -21,16 +21,16 @@ class ChangeAddressUseCase {
 			return ChangeAddressResponse::newErrorResponse( ['Unknown address.'] );
 		}
 
-		try {
-			if ( !$request->isOnlyOptInDonationReceiptRequest() ) {
+		if ( $request->hasAddressChangeData() ) {
+			try {
 				$addressChange->performAddressChange( $this->buildAddress( $request ) );
 			}
-		}
-		catch ( ChangeAddressValidationException $e ) {
-			return ChangeAddressResponse::newErrorResponse( [ $e->getMessage() ] );
+			catch ( ChangeAddressValidationException $e ) {
+				return ChangeAddressResponse::newErrorResponse( [ $e->getMessage() ] );
+			}
 		}
 
-		if ( ! $request->isOptedIntoDonationReceipt() ) {
+		if ( $request->isOptedOutOfDonationReceipt() ) {
 			$addressChange->optOutOfDonationReceipt();
 		}
 


### PR DESCRIPTION
Move boolean negations into getters to make the calling code read more
fluently. Setters (used in FundraisingFrontend) are not affected.

Invert nesting of `if` and `try` to make `try` block more localized