### PR TITLE
Add external references to AddressChange

### DIFF
--- a/config/DoctrineClassMapping/WMDE.Fundraising.AddressChange.Domain.Model.AddressChange.dcm.xml
+++ b/config/DoctrineClassMapping/WMDE.Fundraising.AddressChange.Domain.Model.AddressChange.dcm.xml
@@ -23,6 +23,8 @@
       </options>
     </field>
     <field name="addressType" type="string" column="address_type" length="10" nullable="false" />
+    <field name="externalId" type="integer" column="external_id" nullable="false" />
+    <field name="externalIdType" type="string" column="external_id_type" length="10" nullable="false" />
     <field name="exportDate" type="datetime" column="export_date" nullable="true" />
     <field name="createdAt" type="datetime" column="created_at" nullable="false" />
     <field name="modifiedAt" type="datetime" column="modified_at" nullable="false" />

--- a/src/Domain/Model/AddressChangeBuilder.php
+++ b/src/Domain/Model/AddressChangeBuilder.php
@@ -1,0 +1,81 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\AddressChangeContext\Domain\Model;
+
+use WMDE\Fundraising\AddressChange\Domain\Model\Address;
+use WMDE\Fundraising\AddressChange\Domain\Model\AddressChange;
+
+class AddressChangeBuilder {
+
+	/**
+	 * @var string
+	 */
+	private $addressType;
+
+	/**
+	 * @var string
+	 */
+	private $referenceType;
+
+	/**
+	 * @var int
+	 */
+	private $referenceId;
+
+	private $id;
+	private $address;
+	private $createdAt;
+
+	public function __construct( ?string $identifier = null, ?Address $address = null, ?\DateTime $createdAt = null ) {
+		$this->id = $identifier;
+		$this->address = $address;
+		$this->createdAt = $createdAt;
+	}
+
+	public static function create( ?string $identifier = null, ?Address $address = null, ?\DateTime $createdAt = null ): self {
+		return new self( $identifier, $address, $createdAt );
+	}
+
+	public function forPerson(): self {
+		return $this->setAddressType( AddressChange::ADDRESS_TYPE_PERSON );
+	}
+
+	public function forCompany(): self {
+		return $this->setAddressType( AddressChange::ADDRESS_TYPE_COMPANY );
+	}
+
+	private function setAddressType( string $addressType ): self {
+		if ( $this->addressType !== null ) {
+			throw new \RuntimeException( 'You can only specify address type once' );
+		}
+		$this->addressType = $addressType;
+		return $this;
+	}
+
+	public function forDonation( int $donationId ): self {
+		return $this->setReference( $donationId, AddressChange::EXTERNAL_ID_TYPE_DONATION );
+	}
+
+	public function forMembership( int $membershipId ): self {
+		return $this->setReference( $membershipId, AddressChange::EXTERNAL_ID_TYPE_MEMBERSHIP );
+	}
+
+	private function setReference( int $referenceId, string $referenceType ): self {
+		if ( $this->referenceType !== null ) {
+			throw new \RuntimeException( 'You can only specify reference type once' );
+		}
+		$this->referenceType = $referenceType;
+		$this->referenceId = $referenceId;
+		return $this;
+	}
+
+	public function build(): AddressChange {
+		if ( $this->referenceType === null || $this->addressType === null ) {
+			throw new \RuntimeException( 'You must specify address type and reference' );
+		}
+		return new AddressChange( $this->addressType, $this->referenceType, $this->referenceId, $this->id, $this->address, $this->createdAt );
+	}
+
+}

--- a/tests/Unit/Domain/Model/AddressChangeBuilderTest.php
+++ b/tests/Unit/Domain/Model/AddressChangeBuilderTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\AddressChangeContext\Tests\Unit\Domain\Model;
+
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\AddressChange\Domain\Model\Address;
+use WMDE\Fundraising\AddressChange\Domain\Model\AddressChange;
+use WMDE\Fundraising\AddressChangeContext\Domain\Model\AddressChangeBuilder;
+
+class AddressChangeBuilderTest extends TestCase {
+
+	public function testGivenParametersForCreateTheyArePassedToAddressChange(): void {
+		$identifier = '77c12190-d97a-4564-9d88-160be51dd134';
+		$address = Address::newCompanyAddress( 'Bank of Duckburg', 'At the end of teh road', '1234', 'Duckburg', 'DE' );
+		$addressChange = AddressChangeBuilder::create( $identifier, $address )->forPerson()->forDonation( 1 )->build();
+
+		$this->assertSame( $identifier, $addressChange->getCurrentIdentifier() );
+		$this->assertSame( $address, $addressChange->getAddress() );
+	}
+
+	public function testBuildPersonalAddressChangeForDonation(): void {
+		$addressChange = AddressChangeBuilder::create()->forPerson()->forDonation( 1 )->build();
+
+		$this->assertTrue( $addressChange->isPersonalAddress() );
+		$this->assertSame( 1, $addressChange->getExternalId() );
+		$this->assertSame( AddressChange::EXTERNAL_ID_TYPE_DONATION, $addressChange->getExternalIdType() );
+	}
+
+	public function testBuildCompanyAddressChangeForDonation(): void {
+		$addressChange = AddressChangeBuilder::create()->forCompany()->forDonation( 1 )->build();
+
+		$this->assertTrue( $addressChange->isCompanyAddress() );
+	}
+
+	public function testBuildPersonalAddressChangeForMembership(): void {
+		$addressChange = AddressChangeBuilder::create()->forPerson()->forMembership( 3 )->build();
+
+		$this->assertSame( 3, $addressChange->getExternalId() );
+		$this->assertSame( AddressChange::EXTERNAL_ID_TYPE_MEMBERSHIP, $addressChange->getExternalIdType() );
+	}
+
+	public function testPersonCannotBeChangedToCompany(): void {
+		$this->expectException( \RuntimeException::class );
+
+		AddressChangeBuilder::create()->forPerson()->forCompany();
+	}
+
+	public function testCompanyCannotBeChangedToPerson(): void {
+		$this->expectException( \RuntimeException::class );
+
+		AddressChangeBuilder::create()->forCompany()->forPerson();
+	}
+
+	public function testDonationCannotBeChangedToMembership(): void {
+		$this->expectException( \RuntimeException::class );
+
+		AddressChangeBuilder::create()->forDonation( 1 )->forMembership( 1 );
+	}
+
+	public function testMembershipCannotBeChangedToDonation(): void {
+		$this->expectException( \RuntimeException::class );
+
+		AddressChangeBuilder::create()->forMembership( 1 )->forDonation( 1 );
+	}
+
+	public function testAddressAndReferenceTypeHaveToBeSpecified(): void {
+		$this->expectException( \RuntimeException::class );
+
+		AddressChangeBuilder::create()->build();
+	}
+}

--- a/tests/Unit/UseCases/ChangeAddressUseCaseTest.php
+++ b/tests/Unit/UseCases/ChangeAddressUseCaseTest.php
@@ -16,11 +16,12 @@ use WMDE\Fundraising\AddressChange\UseCases\ChangeAddress\ChangeAddressUseCase;
 class ChangeAddressUseCaseTest extends TestCase {
 
 	private const VALID_SAMPLE_UUID = 'd8441c6e-1f7a-4710-97d3-0e2126c86d40';
+	private const DUMMY_DONATION_ID = 0;
 
 	public function testGivenValidAddressChangeRequest_successResponseIsReturned(): void {
 		$mockAddressChangeRepository = $this->createMock( AddressChangeRepository::class );
 		$mockAddressChangeRepository->method( 'getAddressChangeByUuid' )->willReturn(
-			AddressChange::createNewPersonAddressChange( self::VALID_SAMPLE_UUID )
+			$this->createAddressChange()
 		);
 		$useCase = new ChangeAddressUseCase( $mockAddressChangeRepository );
 		$response = $useCase->changeAddress( $this->newChangeAddressRequest() );
@@ -30,7 +31,7 @@ class ChangeAddressUseCaseTest extends TestCase {
 	public function testGivenInvalidAddressChangeRequest_errorResponseIsReturned(): void {
 		$mockAddressChangeRepository = $this->createMock( AddressChangeRepository::class );
 		$mockAddressChangeRepository->method( 'getAddressChangeByUuid' )->willReturn(
-			AddressChange::createNewPersonAddressChange( self::VALID_SAMPLE_UUID )
+			$this->createAddressChange()
 		);
 		$useCase = new ChangeAddressUseCase( $mockAddressChangeRepository );
 		$response = $useCase->changeAddress( $this->newMissingDataChangeAddressRequest() );
@@ -50,7 +51,7 @@ class ChangeAddressUseCaseTest extends TestCase {
 	public function testGivenValidOptOutOnlyChangeRequest_successResponseIsReturned(): void {
 		$mockAddressChangeRepository = $this->createMock( AddressChangeRepository::class );
 		$mockAddressChangeRepository->method( 'getAddressChangeByUuid' )->willReturn(
-			AddressChange::createNewPersonAddressChange( self::VALID_SAMPLE_UUID )
+			$this->createAddressChange()
 		);
 		$useCase = new ChangeAddressUseCase( $mockAddressChangeRepository );
 		$response = $useCase->changeAddress( $this->newOptOutOnlyRequest() );
@@ -60,7 +61,7 @@ class ChangeAddressUseCaseTest extends TestCase {
 	public function testGivenEmptyAddressChangeRequest_errorResponseIsReturned(): void {
 		$mockAddressChangeRepository = $this->createMock( AddressChangeRepository::class );
 		$mockAddressChangeRepository->method( 'getAddressChangeByUuid' )->willReturn(
-			AddressChange::createNewPersonAddressChange( self::VALID_SAMPLE_UUID )
+			$this->createAddressChange()
 		);
 		$useCase = new ChangeAddressUseCase( $mockAddressChangeRepository );
 		$response = $useCase->changeAddress( $this->newEmptyChangeAddressRequest() );
@@ -137,6 +138,10 @@ class ChangeAddressUseCaseTest extends TestCase {
 		$request->setIsOptOutOnly( true );
 		$request->freeze();
 		return $request;
+	}
+
+	private function createAddressChange(): AddressChange {
+		return new AddressChange( AddressChange::ADDRESS_TYPE_PERSON, AddressChange::EXTERNAL_ID_TYPE_DONATION, self::DUMMY_DONATION_ID, self::VALID_SAMPLE_UUID );
 	}
 
 }


### PR DESCRIPTION
This change prepares the inversion of the relationship between
donations, memberships and address changes.

Introduced a builder class as the recommended way to build an address
change.

The migration for this change was done in FundraisingStore.