### PR TITLE
Generate coverage report in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ composer.lock
 
 vendor/
 build/
+coverage/
 
 .floo
 .flooignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,11 @@ install:
 
 script:
   - make install-php
-  - make ci
+  - make ci-with-coverage COVERAGE_FLAGS="--coverage-clover coverage.clover"
   - make install-php COMPOSER_FLAGS="--no-dev -q" # Remove dev dependencies to make sure PHPStan creates errors if prod code depends on dev classes
   - docker run -v $PWD:/app --rm ghcr.io/phpstan/phpstan analyse --level 7 --no-progress src/ # Can't use "make stan" because stan was removed
 
 after_success:
-  - vendor/bin/phpunit --coverage-clover coverage.clover
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ current_group   := $(shell id -g)
 BUILD_DIR       := $(PWD)
 DOCKER_FLAGS    := --interactive --tty
 DOCKER_IMAGE    := registry.gitlab.com/fun-tech/fundraising-frontend-docker
+COVERAGE_FLAGS  := --coverage-html coverage
 
 install-php:
 	docker run --rm $(DOCKER_FLAGS) --volume $(BUILD_DIR):/app -w /app --volume ~/.composer:/composer --user $(current_user):$(current_group) $(DOCKER_IMAGE):composer composer install $(COMPOSER_FLAGS)
@@ -20,7 +21,7 @@ phpunit:
 	docker-compose run --rm --no-deps app ./vendor/bin/phpunit
 
 phpunit-with-coverage:
-	docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --rm --no-deps -e XDEBUG_MODE=coverage app_debug ./vendor/bin/phpunit --coverage-clover coverage.clover
+	docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --rm --no-deps -e XDEBUG_MODE=coverage app_debug ./vendor/bin/phpunit $(COVERAGE_FLAGS)
 
 cs:
 	docker-compose run --rm --no-deps app ./vendor/bin/phpcs


### PR DESCRIPTION
https://phabricator.wikimedia.org/T284180

Our old travis file tried to run PHPUnit after is was uninstalled,
leading to a missing coverage report file.

This change add coverage report output flags to the Makefile to
generate HTML by default and Clover XML when run through Travis.