### PR TITLE
Add Symfony Cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
 		"php": ">=7.4",
 		"doctrine/dbal": "^2.10",
 		"doctrine/orm": "^2.7",
+		"symfony/cache": "^5.3",
 		"ramsey/uuid": "^4.0",
 		"wmde/freezable-value-object": "~2.0"
 	},


### PR DESCRIPTION
Doctrine v2.9 removed internal caching lib so we now need to use the Symfony one.