### PR TITLE
Fix test environment for doctrine-common 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,10 @@
 		"psr-4": {
 			"WMDE\\Fundraising\\AddressChangeContext\\Tests\\": "tests/"
 		}
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/package-versions-deprecated": true
+		}
 	}
 }

--- a/src/AddressChangeContextFactory.php
+++ b/src/AddressChangeContextFactory.php
@@ -21,9 +21,6 @@ class AddressChangeContextFactory {
 	private const DOCTRINE_CLASS_MAPPING_DIRECTORY = __DIR__ . '/../config/DoctrineClassMapping';
 
 	public function newMappingDriver(): MappingDriver {
-		// We're only calling this for the side effect of adding Mapping/Driver/DoctrineAnnotations.php
-		// to the AnnotationRegistry. When AnnotationRegistry is deprecated with Doctrine Annotations 2.0,
-		// use $this->annotationReader instead
 		return new XmlDriver( self::DOCTRINE_CLASS_MAPPING_DIRECTORY );
 	}
 

--- a/tests/TestAddressChangeContextFactory.php
+++ b/tests/TestAddressChangeContextFactory.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\AddressChangeContext\Tests;
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\Configuration;
@@ -34,7 +33,6 @@ class TestAddressChangeContextFactory {
 
 	public function getEntityManager(): EntityManager {
 		if ( $this->entityManager === null ) {
-			AnnotationRegistry::registerLoader( 'class_exists' );
 
 			$this->doctrineConfig->setMetadataDriverImpl( $this->factory->newMappingDriver() );
 


### PR DESCRIPTION
Remove references to Doctrine Annotations, which we aren't using in this
repo, we use XML mappings instead of annotations for our entities.

Remove misleading comment from AddressChangeContextFactory (which only
applies if we're using annotations). This was probably copy-pasted.

At some point in the past, doctrine ORM switched from doctrine-common
2.x to 3.x. This got rid of the doctrine-annotations dependency, making
our CI fail.
