### PR TITLE
Modernize Doctrine initialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,10 @@
-dist: trusty
-
 services:
   - docker
 
 language: php
 
-matrix:
-  fast_finish: true
-  include:
-    - php: 7.4
-      env: TYPE=coverage
-  # More PHP instances with different environment variables may be added here
-  # This may be useful if a additional PHP versions or DBMS (SQLite, ...) should be tested by Travis
+php:
+  - 8.1
 
 install:
   - travis_retry make install-php
@@ -20,7 +13,7 @@ script:
   - make install-php
   - make ci-with-coverage COVERAGE_FLAGS="--coverage-clover coverage.clover"
   - make install-php COMPOSER_FLAGS="--no-dev -q" # Remove dev dependencies to make sure PHPStan creates errors if prod code depends on dev classes
-  - docker run -v $PWD:/app --rm ghcr.io/phpstan/phpstan analyse --level 7 --no-progress src/ # Can't use "make stan" because stan was removed
+  - docker run -v $PWD:/app --rm ghcr.io/phpstan/phpstan:1-php8.1 analyse --level 7 --no-progress src/ # Can't use "make stan" because stan was removed
 
 after_success:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/src/AddressChangeContextFactory.php
+++ b/src/AddressChangeContextFactory.php
@@ -5,8 +5,6 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\AddressChangeContext;
 
 use Doctrine\Common\EventSubscriber;
-use Doctrine\ORM\Mapping\Driver\XmlDriver;
-use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 
 /**
  * @license GPL-2.0-or-later
@@ -20,8 +18,11 @@ class AddressChangeContextFactory {
 
 	private const DOCTRINE_CLASS_MAPPING_DIRECTORY = __DIR__ . '/../config/DoctrineClassMapping';
 
-	public function newMappingDriver(): MappingDriver {
-		return new XmlDriver( self::DOCTRINE_CLASS_MAPPING_DIRECTORY );
+	/**
+	 * @return string[]
+	 */
+	public function getDoctrineMappingPaths(): array {
+		return [ self::DOCTRINE_CLASS_MAPPING_DIRECTORY ];
 	}
 
 	/**

--- a/tests/TestAddressChangeContextFactory.php
+++ b/tests/TestAddressChangeContextFactory.php
@@ -8,17 +8,15 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
-use WMDE\Fundraising\AddressChangeContext\AddressChangeContextFactory;
 
 class TestAddressChangeContextFactory {
 
 	private Configuration $doctrineConfig;
-	private AddressChangeContextFactory $factory;
 	private Connection $connection;
 	private ?EntityManager $entityManager;
 
 	/**
-	 * @param array<mixed> $config
+	 * @param array<string,mixed> $config
 	 * @param Configuration $doctrineConfig
 	 *
 	 * @throws \Doctrine\DBAL\Exception
@@ -27,16 +25,13 @@ class TestAddressChangeContextFactory {
 		$this->doctrineConfig = $doctrineConfig;
 
 		$this->connection = DriverManager::getConnection( $config['db'] );
-		$this->factory = new AddressChangeContextFactory();
 		$this->entityManager = null;
 	}
 
 	public function getEntityManager(): EntityManager {
 		if ( $this->entityManager === null ) {
 
-			$this->doctrineConfig->setMetadataDriverImpl( $this->factory->newMappingDriver() );
-
-			$this->entityManager = EntityManager::create(
+			$this->entityManager = new EntityManager(
 				$this->connection,
 				$this->doctrineConfig
 			);

--- a/tests/TestEnvironment.php
+++ b/tests/TestEnvironment.php
@@ -6,7 +6,8 @@ namespace WMDE\Fundraising\AddressChangeContext\Tests;
 
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Tools\Setup;
+use Doctrine\ORM\ORMSetup;
+use WMDE\Fundraising\AddressChangeContext\AddressChangeContextFactory;
 
 /**
  * @license GPL-2.0-or-later
@@ -26,6 +27,7 @@ class TestEnvironment {
 	}
 
 	public static function newInstance(): self {
+		$contextFactory = new AddressChangeContextFactory();
 		$environment = new self(
 			[
 				'db' => [
@@ -33,7 +35,7 @@ class TestEnvironment {
 					'memory' => true,
 				]
 			],
-			Setup::createConfiguration( true )
+			ORMSetup::createXMLMetadataConfiguration( $contextFactory->getDoctrineMappingPaths() )
 		);
 
 		$environment->install();


### PR DESCRIPTION
Replace newMappingDriver with getDoctrineMappingPaths in AddressChangeContextFactory. This is a BC break, but won't break the dependent code.

Update EntityManager initialization in tests.

Ticket: https://phabricator.wikimedia.org/T312080