### PR TITLE
Update PHP version and fix Scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -17,6 +17,7 @@ filter:
     - 'vendor/'
 
 build:
+  image: default-bionic
   nodes:
     analysis:
       tests:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ script:
     #- docker run -v $PWD:/app --rm registry.gitlab.com/fun-tech/fundraising-frontend-docker:stan analyse --level 7 --no-progress src/ # Can't use "make stan" because stan was removed
 
 after_success:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - composer global require scrutinizer/ocular
+  - "$(composer config --global home)/vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover"
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Address change use case for fundraising application",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"php": ">=8.0",
+		"php": ">=8.1",
 		"doctrine/orm": "^2.11",
 		"doctrine/dbal": "^3.3",
 		"ramsey/uuid": "^4.0",


### PR DESCRIPTION
Scrutinizer can't install PHP >=8.1 out of the box, because by default it uses Ubuntu 14.04

See https://scrutinizer-ci.com/docs/guides/upgrading-trusty-image
and https://prinsfrank.nl/2022/02/04/Configuring-PHP8.1-on-scrutinizer

Also, the `ocular.phar` for coverage upload has bundled dependencies broken on newer PHP versions and has to be installed through composer
