### PR TITLE
Improve Address change ID handling

### DIFF
--- a/src/Domain/Model/AddressChange.php
+++ b/src/Domain/Model/AddressChange.php
@@ -120,8 +120,10 @@ class AddressChange {
 	}
 
 	private function markAsModified( AddressChangeId $newIdentifier ): void {
-		$this->previousIdentifier = $this->getCurrentIdentifier();
-		$this->identifier = $newIdentifier;
+		if ( !$this->getCurrentIdentifier()->equals( $newIdentifier ) ) {
+			$this->previousIdentifier = $this->getCurrentIdentifier();
+			$this->identifier = $newIdentifier;
+		}
 
 		$this->modifiedAt = new \DateTime();
 		$this->resetExportState();

--- a/src/Domain/Model/AddressChange.php
+++ b/src/Domain/Model/AddressChange.php
@@ -115,6 +115,10 @@ class AddressChange {
 		return $this->createdAt < $this->modifiedAt;
 	}
 
+	public function hasBeenUsed(): bool {
+		return !$this->getCurrentIdentifier()->equals( $this->previousIdentifier );
+	}
+
 	private function markAsModified( AddressChangeId $newIdentifier ): void {
 		$this->previousIdentifier = $this->getCurrentIdentifier();
 		$this->identifier = $newIdentifier;

--- a/src/Domain/Model/AddressChangeId.php
+++ b/src/Domain/Model/AddressChangeId.php
@@ -25,4 +25,8 @@ class AddressChangeId {
 		return $this->identifier;
 	}
 
+	public function equals( string|AddressChangeId $id ): bool {
+		return is_string( $id ) ? $this->identifier === $id : $this->identifier === $id->identifier;
+	}
+
 }

--- a/tests/Unit/Domain/Model/AddressChangeIdTest.php
+++ b/tests/Unit/Domain/Model/AddressChangeIdTest.php
@@ -22,7 +22,7 @@ class AddressChangeIdTest extends TestCase {
 	/**
 	 * @dataProvider invalidUUIDProvider
 	 */
-	public function testPersonalAddressChangeThrowsExceptionsWhenUUIDIsInvalid( string $invalidUUID ): void {
+	public function testThrowsExceptionsWhenUUIDIsInvalid( string $invalidUUID ): void {
 		$this->expectException( \InvalidArgumentException::class );
 		AddressChangeId::fromString( $invalidUUID );
 	}
@@ -36,5 +36,20 @@ class AddressChangeIdTest extends TestCase {
 		yield [ '1111222233334444-1111222233334444-1111222233334444-1111222233334444-1111222233334444' ];
 		yield [ 'e-f-f-e-d' ];
 		yield [ 'This-is-not-a-UUID' ];
+	}
+
+	public function testCanCheckEqualityWithStrings(): void {
+		$uuid = '72dfed91-fa40-4af0-9e80-c6010ab29cd1';
+		$addressChangeId = AddressChangeId::fromString( $uuid );
+
+		$this->assertTrue( $addressChangeId->equals( $uuid ), 'IDs should compare equals' );
+	}
+
+	public function testCanCheckEqualityWithOtherID(): void {
+		$uuid = '72dfed91-fa40-4af0-9e80-c6010ab29cd1';
+		$addressChangeId = AddressChangeId::fromString( $uuid );
+		$addressChangeIdWithSameUUID = AddressChangeId::fromString( $uuid );
+
+		$this->assertTrue( $addressChangeId->equals( $addressChangeIdWithSameUUID ), 'IDs should compare equals' );
 	}
 }

--- a/tests/Unit/Domain/Model/AddressChangeTest.php
+++ b/tests/Unit/Domain/Model/AddressChangeTest.php
@@ -132,4 +132,24 @@ class AddressChangeTest extends TestCase {
 
 		$this->assertEquals( AddressChange::EXPORT_STATE_USED_EXPORTED, $addressChange->getExportState() );
 	}
+
+	public function testNewAddressChangesAreUnused(): void {
+		$addressChange = new AddressChange( AddressType::Person, AddressChange::EXTERNAL_ID_TYPE_DONATION, self::DUMMY_DONATION_ID, $this->identifier );
+
+		$this->assertFalse( $addressChange->hasBeenUsed() );
+	}
+
+	public function testAddressChangesWithAddressesAreUsed(): void {
+		$addressChange = new AddressChange( AddressType::Person, AddressChange::EXTERNAL_ID_TYPE_DONATION, self::DUMMY_DONATION_ID, $this->identifier );
+		$addressChange->performAddressChange( ValidAddress::newValidPersonalAddress(), $this->newIdentifier );
+
+		$this->assertTrue( $addressChange->hasBeenUsed() );
+	}
+
+	public function testAddressChangesWithOptOutAreUsed(): void {
+		$addressChange = new AddressChange( AddressType::Person, AddressChange::EXTERNAL_ID_TYPE_DONATION, self::DUMMY_DONATION_ID, $this->identifier );
+		$addressChange->optOutOfDonationReceipt( $this->newIdentifier );
+
+		$this->assertTrue( $addressChange->hasBeenUsed() );
+	}
 }

--- a/tests/Unit/Domain/Model/AddressChangeTest.php
+++ b/tests/Unit/Domain/Model/AddressChangeTest.php
@@ -152,4 +152,15 @@ class AddressChangeTest extends TestCase {
 
 		$this->assertTrue( $addressChange->hasBeenUsed() );
 	}
+
+	public function testMultipleModificationsWithTheSameIdentifierKeepsIdentifiers(): void {
+		$addressChange = $this->newPersonAddressChange();
+		$initialIdentifier = $addressChange->getCurrentIdentifier();
+
+		$addressChange->performAddressChange( ValidAddress::newValidPersonalAddress(), $this->newIdentifier );
+		$addressChange->optOutOfDonationReceipt( $this->newIdentifier );
+
+		$this->assertEquals( $initialIdentifier, $addressChange->getPreviousIdentifier() );
+		$this->assertEquals( $this->newIdentifier, $addressChange->getCurrentIdentifier() );
+	}
 }


### PR DESCRIPTION
- Allow for better comparison
- Allow for checking if an address change record is "fresh" (i.e. never been used) by comparing its IDs
- Don't "rotate" IDs if an address change record is modified several times with the same ID (e.g. changing address *and* opting out of the receipt)